### PR TITLE
option to start containers, or not

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -132,3 +132,4 @@
   with_items:
     - absent
     - present
+  when: start_containers | default(true)


### PR DESCRIPTION
Because sometimes after we set up the container, we want to take additional steps to set up the mounted volumes.

Example:
1. Set up nginx (all directories cleaned out)
2. Copy certs from local:/my/certs-and-keys-secret-do-not-touch/ to remote:<project_src>/certs
3. Start up nginx.

Currently 1 and 3 are bundled together in docker-compose-ansible, making inserting step 2 difficult.

This PR disables step 3, so that we can start the container separately after we have done step 2