### PR TITLE
Force a become when removing files

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -72,6 +72,7 @@
     state: absent
   with_items: "{{ project_directory_files }}"
   when: code_source == 'local'
+  become: {{ docker_become }}
 - name: "List top level directories in {{ project_directory }}"
   find:
     paths: "{{ project_directory }}"
@@ -90,6 +91,7 @@
     state: absent
   with_items: "{{ project_directory_directories }}"
   when: code_source == 'local'
+  become: {{ docker_become }}
 - name: "Untar to {{ project_directory }}"
   unarchive:
     copy: yes


### PR DESCRIPTION
Here's the problem

1. Mount some docker volume
2. Container writes files as root to docker volume
3. Script cannot clear out the files any more.

I'm not sure if this is the solution...