### PR TITLE
don't pull when building -- for better offline support

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -115,7 +115,7 @@
   when: pull_images
 - name: "Docker-compose Build"
   shell:
-    cmd: "docker-compose {{ docker_compose_switch }} build --pull"
+    cmd: "docker-compose {{ docker_compose_switch }} build {{ pull_images | ternary('--pull', '') }}"
     chdir: "{{ project_directory }}"
   args:
     warn: False
@@ -125,7 +125,7 @@
   docker_service:
     project_src: "{{ project_directory }}"
     project_name: "{{ project_name | default(omit) }}"
-    build: "{{ build_images }}"
+    build: False
     files: "{{ docker_compose_files }}"
     remove_volumes: "{{ remove_volumes | default(no) }}"
     state: "{{ item }}"


### PR DESCRIPTION
1. Do not specify --pull if pull_images is false
2. Since we already built the images previously, there's no need to build the images again