### PR TITLE
Ensure that permissions are preserved in unarchive

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -94,7 +94,7 @@
   become: "{{ docker_become }}"
 - name: "Untar to {{ project_directory }}"
   unarchive:
-    copy: yes
+    extra_opts: [-p]
     src: "{{ temp_file.stdout }}"
     dest: "{{ project_directory }}"
   when: code_source == 'local'


### PR DESCRIPTION
1. Remove `copy: yes` as this is default when `remote_src` is not specified
2. Preserve permissions when unarchiving (-p is not set by default when not running as root, e.g. user in `docker` group)